### PR TITLE
APC error on drupal playbook #4

### DIFF
--- a/drupal/provisioning/playbook.yml
+++ b/drupal/provisioning/playbook.yml
@@ -90,7 +90,7 @@
 
   - name: Enable upload progress via APC.
     lineinfile:
-      dest: "/etc/php5/conf.d/20-apc.ini"
+      dest: "/etc/php5/apache2/conf.d/20-apcu.ini"
       regexp: "^apc.rfc1867"
       line: "apc.rfc1867 = 1"
       state: present


### PR DESCRIPTION
Vagrant Up continues to abort as per #4