### PR TITLE
Update creates parameter in Solr playbook

### DIFF
--- a/solr/provisioning/playbook.yml
+++ b/solr/provisioning/playbook.yml
@@ -57,7 +57,7 @@
         # Solr log4j logging configuration.
         - src: "{{ solr_dir }}/example/lib/ext/*"
           dest: "/var/lib/tomcat7/shared/"
-          creates: "/var/lib/tomcat7/shared/log4j-1.2.16.jar"
+          creates: "/var/lib/tomcat7/shared/log4j-1.2.17.jar"
 
         - src: "{{ solr_dir }}/example/resources/log4j.properties"
           dest: "/var/lib/tomcat7/shared/classes"


### PR DESCRIPTION
The "Copy Solr components into place" task says that the cp command creates the file `/var/lib/tomcat7/shared/log4j-1.2.16.jar`. However, Solr 4.10.4 ships with `log4j-1.2.17.jar`. This causes the play to fail on subsequent invocations as Ansible will attempt to copy the components again after the source files have been deleted.

Relevant output of `vagrant provision` after a successfully running `vagrant up`:
```
TASK: [Copy Solr components into place.] ************************************** 
ok: [default] => (item={'dest': u'/opt/solr/solr.war', 'src': u'/opt/solr/example/webapps/solr.war', 'creates': u'/opt/solr/solr.war'})
ok: [default] => (item={'dest': u'/opt/solr/', 'src': u'/opt/solr/example/solr/*', 'creates': u'/opt/solr/solr.xml'})
failed: [default] => (item={'dest': '/var/lib/tomcat7/shared/', 'src': u'/opt/solr/example/lib/ext/*', 'creates': '/var/lib/tomcat7/shared/log4j-1.2.16.jar'}) => {"changed": true, "cmd": "cp -r /opt/solr/example/lib/ext/* /var/lib/tomcat7/shared/", "delta": "0:00:00.002654", "end": "2016-01-09 02:25:52.549604", "item": {"creates": "/var/lib/tomcat7/shared/log4j-1.2.16.jar", "dest": "/var/lib/tomcat7/shared/", "src": "/opt/solr/example/lib/ext/*"}, "rc": 1, "start": "2016-01-09 02:25:52.546950", "warnings": []}
stderr: cp: cannot stat `/opt/solr/example/lib/ext/*': No such file or directory
ok: [default] => (item={'dest': '/var/lib/tomcat7/shared/classes', 'src': u'/opt/solr/example/resources/log4j.properties', 'creates': '/var/lib/tomcat7/shared/classes/log4j.properties'})

FATAL: all hosts have already failed -- aborting

```