### PR TITLE
JGoin | Fixed the dest definition for apcu.ini

### DIFF
--- a/drupal/provisioning/playbook.yml
+++ b/drupal/provisioning/playbook.yml
@@ -79,7 +79,7 @@
 
     - name: Enable upload progress via APC.
       lineinfile:
-        dest: "/etc/php5/apache2/conf.d/20-apcu.ini"
+        dest: "/etc/php5/mods-available/apcu.ini"
         regexp: "^apc.rfc1867"
         line: "apc.rfc1867 = 1"
         state: present


### PR DESCRIPTION
This broke in my local testing, probably a change with how `php5` handles modules now in the Ubuntu package or something.  This fixes it.  See #34 for further info. 