### PR TITLE
Fix link for Solr

### DIFF
--- a/solr/provisioning/playbook.yml
+++ b/solr/provisioning/playbook.yml
@@ -24,7 +24,7 @@
 
     - name: Download Solr.
       get_url:
-        url: "http://apache.osuosl.org/lucene/solr/{{ solr_version }}/solr-{{ solr_version }}.tgz"
+        url: "https://archive.apache.org/dist/lucene/solr/{{ solr_version }}/solr-{{ solr_version }}.tgz"
         dest: "{{ download_dir }}/solr-{{ solr_version }}.tgz"
         sha256sum: "{{ solr_sha256sum }}"
 


### PR DESCRIPTION
SolR (at least version 4.10.4) is no longer available from this link:

http://apache.osuosl.org/lucene/solr/{{ solr_version }}/solr-{{ solr_version }}.tgz

(e.g. http://apache.osuosl.org/lucene/solr/4.10.4/solr-4.10.4.tgz), but it is available from the suggested one and the playbook completes successfully.