### PR TITLE
Fix cache-max-age CLI option and typo

### DIFF
--- a/dynamic-inventory/digitalocean/digital_ocean.py
+++ b/dynamic-inventory/digitalocean/digital_ocean.py
@@ -192,7 +192,7 @@ or environment variables (DO_API_TOKEN)''')
         self.cache_filename = self.cache_path + "/ansible-digital_ocean.cache"
         self.cache_refreshed = False
 
-        if self.is_cache_valid:
+        if self.is_cache_valid():
             self.load_from_cache()
             if len(self.data) == 0:
                 if self.args.force_cache:
@@ -294,7 +294,7 @@ or environment variables (DO_API_TOKEN)''')
         parser.add_argument('--pretty','-p', action='store_true', help='Pretty-print results')
 
         parser.add_argument('--cache-path', action='store', help='Path to the cache files (default: .)')
-        parser.add_argument('--cache-max_age', action='store', help='Maximum age of the cached items (default: 0)')
+        parser.add_argument('--cache-max_age', action='store', help='Maximum age of the cached items (default: 0)', type=int)
         parser.add_argument('--force-cache', action='store_true', default=False, help='Only use data from the cache')
         parser.add_argument('--refresh-cache','-r', action='store_true', default=False,
                             help='Force refresh of cache by making API requests to DigitalOcean (default: False - use cache files)')
@@ -306,6 +306,9 @@ or environment variables (DO_API_TOKEN)''')
 
         if self.args.api_token:
             self.api_token = self.args.api_token
+
+        if self.args.cache_max_age:
+            self.cache_max_age = self.args.cache_max_age
 
         # Make --list default if none of the other commands are specified
         if (not self.args.droplets and not self.args.regions and


### PR DESCRIPTION
This PR fixes two issues with caching:
1 `self.is_cache_valid` was used instead of the method call, it always returned
true instead of checking the cache validity. I added the parentheses.
2  The command-line option: `--cache-max_age` was never used anywhere. So the max age for the cache could only be specified in a config file. I added code to handle the command-line option.

I checked several scenarios with and without `--force-cache` and by removing the cache file, everything is working like I would expect now.
cc @geerlingguy  