### PR TITLE
Use Droplet tags to create groups of hosts in inventory

### DIFF
--- a/dynamic-inventory/digitalocean/digital_ocean.py
+++ b/dynamic-inventory/digitalocean/digital_ocean.py
@@ -136,8 +136,13 @@ import sys
 import re
 import argparse
 from time import time
-import ConfigParser
 import ast
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
+
 
 try:
     import json

--- a/dynamic-inventory/digitalocean/digital_ocean.py
+++ b/dynamic-inventory/digitalocean/digital_ocean.py
@@ -371,6 +371,15 @@ or environment variables (DO_API_TOKEN)''')
             else:
                 dest = droplet['ip_address']
 
+            for tag in droplet.get('tags', []):
+                if tag not in self.inventory:
+                    self.inventory[tag] = {
+                        'hosts': [],
+                        'vars': {},
+                    }
+
+                self.inventory[tag]['hosts'].append(dest)
+
             self.inventory['all']['hosts'].append(dest)
 
             self.inventory[droplet['id']] = [dest]


### PR DESCRIPTION
This allows selecting machines by tag, so if multiple machines are tagged with, for example, `tag_docker` in DO, Ansible run against all instances with that tag at the same time.