### PR TITLE
Fixed incorrect port number

### DIFF
--- a/solr/README.md
+++ b/solr/README.md
@@ -30,7 +30,7 @@ Note: *If there are any errors during the course of running `vagrant up`, and it
 ### 3 - Configure your host machine to access the VM.
 
   1. [Edit your hosts file](http://www.rackspace.com/knowledge_center/article/how-do-i-modify-my-hosts-file), adding the line `192.168.66.66  solr.test` so you can connect to the VM.
-  2. Open your browser and access [http://solr.test:8080/solr/](http://solr.test:8080/solr).
+  2. Open your browser and access [http://solr.test:8983/solr/](http://solr.test:8983/solr).
 
 ## Notes
 


### PR DESCRIPTION
Solr is running on port 8983 rather than port 8080 when I did the provisioning.