### PR TITLE
Use secured HTTP connection for Drupal download

### DIFF
--- a/includes/provisioning/tasks/drupal.yml
+++ b/includes/provisioning/tasks/drupal.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check out Drupal Core to the Apache docroot.
   git:
-    repo: http://git.drupal.org/project/drupal.git
+    repo: https://git.drupal.org/project/drupal.git
     version: "{{ drupal_core_version }}"
     dest: "{{ drupal_core_path }}"
 


### PR DESCRIPTION
Minor suggestion to use "https://" URLs to pull down when the Git repository supports it.