### PR TITLE
Update playbook.yml in nodejs

### DIFF
--- a/nodejs/provisioning/playbook.yml
+++ b/nodejs/provisioning/playbook.yml
@@ -6,6 +6,9 @@
     node_apps_location: /usr/local/opt/node
 
   tasks:
+    - name: Install EPEL repo.
+      yum: name=epel-release state=present
+      
     - name: Import Remi GPG key.
       rpm_key:
         key: "https://rpms.remirepo.net/RPM-GPG-KEY-remi"
@@ -15,9 +18,6 @@
       yum:
         name: "https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
         state: present
-
-    - name: Install EPEL repo.
-      yum: name=epel-release state=present
 
     - name: Ensure firewalld is stopped (since this is a test server).
       service: name=firewalld state=stopped


### PR DESCRIPTION
**remi-release-7.rpm** has dependency on EPEL thus, **epel-release** needs to be installed first.