### PR TITLE
Update kubectl-connection.yml

### DIFF
--- a/kubernetes/examples/kubectl-connection.yml
+++ b/kubernetes/examples/kubectl-connection.yml
@@ -20,8 +20,7 @@
     - name: Add the phpmyadmin Pod to the inventory.
       add_host:
         name: '{{ phpmyadmin_pod.stdout }}'
-        kubectl_pod: '{{ phpmyadmin_pod.stdout }}'
-        kubectl_namespace: default
+        ansible_kubectl_namespace: default
         ansible_kubectl_config: files/kubectl-config
         ansible_connection: kubectl
 


### PR DESCRIPTION
kubectl_namespace is not a valid variable for this connection plugin and doesn't do anything. It works because the default namespace is already 'default'. See documentation for [reference](https://docs.ansible.com/ansible/latest/plugins/connection/kubectl.html).

```
env: K8S_AUTH_NAMESPACE
var: ansible_kubectl_namespace
```