### PR TITLE
Move success message to `app`'s `listen` callback.

### DIFF
--- a/nodejs-role/app/app.js
+++ b/nodejs-role/app/app.js
@@ -11,5 +11,4 @@ app.get('/', function(req, res){
 });
 
 // Listen on port 80 (like a true web server).
-app.listen(80);
-console.log('Express server started successfully.');
+app.listen(80, () => console.log('Express server started successfully.'));

--- a/nodejs/provisioning/app/app.js
+++ b/nodejs/provisioning/app/app.js
@@ -11,5 +11,4 @@ app.get('/', function(req, res){
 });
 
 // Listen on port 80 (like a true web server).
-app.listen(80);
-console.log('Express server started successfully.');
+app.listen(80, () => console.log('Express server started successfully.'));


### PR DESCRIPTION
express's `server.listen` has an asynchronous nature and it's API enables
providing a callback that is fired upon success. Now the success messaage
is logged only when the server has been set up and listening on provided
socket address, otherwise the error stack trace is printed.