### PR TITLE
drupal playbook failing without acl installed

### DIFF
--- a/drupal/provisioning/playbook.yml
+++ b/drupal/provisioning/playbook.yml
@@ -28,6 +28,7 @@
       apt:
         state: present
         name:
+          - acl
           - git
           - curl
           - unzip


### PR DESCRIPTION
TASK [Install Drupal dependencies with Composer.] ******************************
fatal: [default]: FAILED! => {"msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: changing ownership of '/var/tmp/ansible-tmp-1586697780.51-117703352883265/': Operation not permitted\nchown: changing ownership of '/var/tmp/ansible-tmp-1586697780.51-117703352883265/command.py': Operation not permitted\n}). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}

Fixed by installing `acl` package as per https://github.com/georchestra/ansible/issues/55#issuecomment-564130730