### PR TITLE
Fix capitalization for chrony

### DIFF
--- a/first-ansible-playbook/playbook.yml
+++ b/first-ansible-playbook/playbook.yml
@@ -3,7 +3,7 @@
   become: yes
 
   tasks:
-  - name: Ensure Chrony (for time synchronization) is installed.
+  - name: Ensure chrony (for time synchronization) is installed.
     yum:
       name: chrony
       state: present


### PR DESCRIPTION
Thanks for creating the book and youtube series on ansible, I have found them very useful. 

I noticed a small inconsistency in the capitalization of chrony in the first playbook, this pull requests removes the capital.