### PR TITLE
Update README.md with molecule-docker

### DIFF
--- a/molecule/README.md
+++ b/molecule/README.md
@@ -4,9 +4,9 @@ This directory contains an example Molecule configuration for an Ansible playboo
 
 The Molecule configuration can be run locally or in a Continuous Integration (CI) environment, to ensure the playbook is always working correctly.
 
-To run the Molecule environment, you must have `molecule` and the `docker` Python library installed:
+To run the Molecule environment, you must have `molecule` and the `molecule-docker` Python library installed:
 
-    pip3 install molecule docker
+    pip3 install molecule molecule-docker
 
 Additionally, there are lint tools configured to ensure code formatting is correct, so you need to make sure the lint tools are installed:
 


### PR DESCRIPTION
A small update to remove a potential blocker for people following this chapter. 

The driver for docker is separate since https://github.com/ansible-community/molecule/pull/2811, thus `molecule-docker` should be installed explicitly.