### PR TITLE
Issue #335: Change url of the dynamic inventory script.

### DIFF
--- a/dynamic-inventory/digitalocean/README.md
+++ b/dynamic-inventory/digitalocean/README.md
@@ -7,7 +7,7 @@
 Examples using Ansible's DigitalOcean integration are contained within this directory.
 
   - `provision.yml` contains an example of provisioning a new DigitalOcean droplet, then immediately configuring it with Ansible.
-  - `digital_ocean.py` (and `digital_ocean.ini`) is the DigitalOcean dynamic inventory script included with Ansible. Don't use this copy; get the latest version from the Ansible project: [digital_ocean.py](https://github.com/ansible/ansible/blob/devel/contrib/inventory/digital_ocean.py).
+  - `digital_ocean.py` (and `digital_ocean.ini`) is the DigitalOcean dynamic inventory script included with Ansible. Don't use this copy; get the latest version from the Ansible project: [digital_ocean.py](https://github.com/ansible-collections/community.digitalocean/blob/main/scripts/inventory/digital_ocean.py).
 
 Before you can use either of these examples, you will need to set an environment variable with your DigitalOcean API Personal Access Token:
 


### PR DESCRIPTION
With Ansible 2.10 modules and plugins have been moved to various _collections_. This PR updates the URL of the `digital_ocean.py` script to the new repository.