### PR TITLE
Fix pip install for jenkins

### DIFF
--- a/jenkins/provision.yml
+++ b/jenkins/provision.yml
@@ -9,6 +9,10 @@
     jenkins_plugins:
       - ansicolor
 
+  pre_tasks:
+    - name: Update apt cache if needed.
+      apt: update_cache=yes cache_valid_time=3600
+
   roles:
     - geerlingguy.firewall
     - geerlingguy.pip


### PR DESCRIPTION
One could argue that the problem should be fixed upstream in the pip role.
Updating cache fixes this:

`TASK [geerlingguy.pip : Ensure Pip is installed.] ******************************  
Monday 08 February 2021  09:25:07 +0100 (0:00:00.043)       0:00:05.954 *******    
fatal: [default]: FAILED! => {"cache_update_time": 1604511616, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Option
s::=--force-confold\"      install 'python3-pip'' failed: E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc-dev-bin_2.31-0ubuntu9.1_amd64.deb  404  Not Found [IP:
 91.189.91.39 80]\nE: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_5.4.0-52.57_amd64.deb  404  Not Found [IP: 91.189.91.39 80]\nE: Failed to fetch http:
//us.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev_2.31-0ubuntu9.1_amd64.deb  404  Not Found [IP: 91.189.91.39 80]\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/z
/zlib/zlib1g-dev_1.2.11.dfsg-2ubuntu1.1_amd64.deb  404  Not Found [IP: 91.189.91.39 80]\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "rc": 100, 
"stderr": "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc-dev-bin_2.31-0ubuntu9.1_amd64.deb  404  Not Found [IP: 91.189.91.39 80]\nE: Failed to fetch http://se
curity.ubuntu.com/ubuntu/pool/main/l/linux/linux-libc-dev_5.4.0-52.57_amd64.deb  404  Not Found [IP: 91.189.91.39 80]\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/g/glib
c/libc6-dev_2.31-0ubuntu9.1_amd64.deb  404  Not Found [IP: 91.189.91.39 80]\nE: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib1g-dev_1.2.11.dfsg-2ubuntu1.1_amd64.d
eb  404  Not Found [IP: 91.189.91.39 80]\nE: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?\n", "stderr_lines": ["E: Failed to fetch http://us.archive.ubu
ntu.com/ubuntu/pool/main/g/glibc/libc-dev-bin_2.31-0ubuntu9.1_amd64.deb  404  Not Found [IP: 91.189.91.39 80]", "E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/linux/linux-
libc-dev_5.4.0-52.57_amd64.deb  404  Not Found [IP: 91.189.91.39 80]", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/g/glibc/libc6-dev_2.31-0ubuntu9.1_amd64.deb  404  Not
 Found [IP: 91.189.91.39 80]", "E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/z/zlib/zlib1g-dev_1.2.11.dfsg-2ubuntu1.1_amd64.deb  404  Not Found [IP: 91.189.91.39 80]", "E
: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe fo
llowing additional packages will be installed:\n  build-essential dpkg-dev fakeroot g++ g++-9 gcc gcc-9 libalgorithm-diff-perl\n  libalgorithm-diff-xs-perl libalgorithm-merge-perl libasan5 l
ibatomic1\n  libc-dev-bin libc6-dev libcc1-0 libcrypt-dev libdpkg-perl libexpat1-dev\n  libfakeroot libfile-fcntllock-perl libgcc-9-dev libgomp1 libitm1 liblsan0\n  libpython3-dev libpython3
.8-dev libquadmath0 libstdc++-9-dev libtsan0\n  libubsan1 linux-libc-dev manpages-dev python-pip-whl python3-dev\n  python3-distutils python3-lib2to3 python3-setuptools python3-wheel\n  pyth
on3.8-dev zlib1g-dev\nSuggested packages:\n  debian-keyring g++-multilib g++-9-multilib gcc-9-doc gcc-multilib autoconf\n  automake libtool flex bison gdb gcc-doc gcc-9-multilib gcc-9-locale
s\n  glibc-doc bzr libstdc++-9-doc python-setuptools-doc\nThe following NEW packages will be installed:\n  build-essential dpkg-dev fakeroot g++ g++-9 gcc gcc-9 libalgorithm-diff-perl\n  lib
algorithm-diff-xs-perl libalgorithm-merge-perl libasan5 libatomic1\n  libc-dev-bin libc6-dev libcc1-0 libcrypt-dev libdpkg-perl libexpat1-dev\n  libfakeroot libfile-fcntllock-perl libgcc-9-d
ev libgomp1 libitm1 liblsan0\n  libpython3-dev libpython3.8-dev libquadmath0 libstdc++-9-dev libtsan0\n  libubsan1 linux-libc-dev manpages-dev python-pip-whl python3-dev\n  python3-distutils
 python3-lib2to3 python3-pip python3-setuptools\n  python3-wheel python3.8-dev zlib1g-dev\n0 upgraded, 41 newly installed, 0 to remove and 64 not upgraded.\nNeed to get 3884 kB/36.6 MB of ar
chives.\nAfter this operation, 161 MB of additional disk space will be used.\nErr:1 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 libc-dev-bin amd64 2.31-0ubuntu9.1\n  404  No
t Found [IP: 91.189.91.39 80]\nIgn:2 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-libc-dev amd64 5.4.0-52.57\nErr:3 http://us.archive.ubuntu.com/ubuntu focal-updates/ma
in amd64 libc6-dev amd64 2.31-0ubuntu9.1\n  404  Not Found [IP: 91.189.91.39 80]\nErr:4 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 zlib1g-dev amd64 1:1.2.11.dfsg-2ubuntu1.1
\n  404  Not Found [IP: 91.189.91.39 80]\nErr:2 http://security.ubuntu.com/ubuntu focal-updates/main amd64 linux-libc-dev amd64 5.4.0-52.57\n  404  Not Found [IP: 91.189.91.39 80]\n", "stdou
t_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following additional packages will be installed:", "  build-essential dpkg-dev fake
root g++ g++-9 gcc gcc-9 libalgorithm-diff-perl", "  libalgorithm-diff-xs-perl libalgorithm-merge-perl libasan5 libatomic1", "  libc-dev-bin libc6-dev libcc1-0 libcrypt-dev libdpkg-perl libe
xpat1-dev", "  libfakeroot libfile-fcntllock-perl libgcc-9-dev libgomp1 libitm1 liblsan0", "  libpython3-dev libpython3.8-dev libquadmath0 libstdc++-9-dev libtsan0", "  libubsan1 linux-libc-
dev manpages-dev python-pip-whl python3-dev", "  python3-distutils python3-lib2to3 python3-setuptools python3-wheel", "  python3.8-dev zlib1g-dev", "Suggested packages:", "  debian-keyring g
++-multilib g++-9-multilib gcc-9-doc gcc-multilib autoconf", "  automake libtool flex bison gdb gcc-doc gcc-9-multilib gcc-9-locales", "  glibc-doc bzr libstdc++-9-doc python-setuptools-doc"
, "The following NEW packages will be installed:", "  build-essential dpkg-dev fakeroot g++ g++-9 gcc gcc-9 libalgorithm-diff-perl", "  libalgorithm-diff-xs-perl libalgorithm-merge-perl liba
san5 libatomic1", "  libc-dev-bin libc6-dev libcc1-0 libcrypt-dev libdpkg-perl libexpat1-dev", "  libfakeroot libfile-fcntllock-perl libgcc-9-dev libgomp1 libitm1 liblsan0", "  libpython3-de
v libpython3.8-dev libquadmath0 libstdc++-9-dev libtsan0", "  libubsan1 linux-libc-dev manpages-dev python-pip-whl python3-dev", "  python3-distutils python3-lib2to3 python3-pip python3-setu
ptools", "  python3-wheel python3.8-dev zlib1g-dev", "0 upgraded, 41 newly installed, 0 to remove and 64 not upgraded.", "Need to get 3884 kB/36.6 MB of archives.", "After this operation, 16
1 MB of additional disk space will be used.", "Err:1 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 libc-dev-bin amd64 2.31-0ubuntu9.1", "  404  Not Found [IP: 91.189.91.39 80]
", "Ign:2 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 linux-libc-dev amd64 5.4.0-52.57", "Err:3 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 libc6-dev amd64 
2.31-0ubuntu9.1", "  404  Not Found [IP: 91.189.91.39 80]", "Err:4 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 zlib1g-dev amd64 1:1.2.11.dfsg-2ubuntu1.1", "  404  Not Found 
[IP: 91.189.91.39 80]", "Err:2 http://security.ubuntu.com/ubuntu focal-updates/main amd64 linux-libc-dev amd64 5.4.0-52.57", "  404  Not Found [IP: 91.189.91.39 80]"]}
[WARNING]: Failure using method (v2_runner_on_failed) in callback plugin
(<ansible.plugins.callback.mail.CallbackModule object at 0x7f973a535c90>):
[Errno 111] Connection refused`