### PR TITLE
Ch4 nodejs Fixes

### DIFF
--- a/nodejs/provisioning/app/package.json
+++ b/nodejs/provisioning/app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "examplenodeapp",
+  "version": "1.0.0",
   "description": "Example Express Node.js app.",
   "author": "Jeff Geerling <geerlingguy@mac.com>",
   "dependencies": {

--- a/nodejs/provisioning/playbook.yml
+++ b/nodejs/provisioning/playbook.yml
@@ -9,16 +9,6 @@
     - name: Install EPEL repo.
       yum: name=epel-release state=present
 
-    - name: Import Remi GPG key.
-      rpm_key:
-        key: "https://rpms.remirepo.net/RPM-GPG-KEY-remi"
-        state: present
-
-    - name: Install Remi repo.
-      yum:
-        name: "https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
-        state: present
-
     - name: Ensure firewalld is stopped (since this is a test server).
       service: name=firewalld state=stopped
 


### PR DESCRIPTION
Removed Remi Repo tasks from Playbook. Remi repo does not contain npm or any of the required RPMs. Added version to package.json to fix bug that existed in version 3.3.0-3.3.1 of community.general.npm module.