### PR TITLE
Update to the centos version number

### DIFF
--- a/orchestration/Vagrantfile
+++ b/orchestration/Vagrantfile
@@ -5,7 +5,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # General Vagrant VM configuration.
-  config.vm.box = "geerlingguy/centos8"
+  config.vm.box = "geerlingguy/centos7"
   config.ssh.insert_key = false
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
Following the latest text from the ansible book, you mention running everything in Centos7 but the Vagrantfile sets up centos8.

"This Vagrantfile defines the three servers we want to manage, and gives each one a
unique hostname, machine name (for VirtualBox), and IP address. For simplicity’s
sake, all three servers will be running CentOS 7."