### PR TITLE
fix:  Vagrant syntax about private_network

### DIFF
--- a/orchestration/Vagrantfile
+++ b/orchestration/Vagrantfile
@@ -16,18 +16,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Application server 1.
   config.vm.define "app1" do |app|
     app.vm.hostname = "orc-app1.test"
-    app.vm.network :private_network, ip: "192.168.60.4"
+    app.vm.network "private_network", ip: "192.168.60.4"
   end
 
   # Application server 2.
   config.vm.define "app2" do |app|
     app.vm.hostname = "orc-app2.test"
-    app.vm.network :private_network, ip: "192.168.60.5"
+    app.vm.network "private_network", ip: "192.168.60.5"
   end
 
   # Database server.
   config.vm.define "db" do |db|
     db.vm.hostname = "orc-db.test"
-    db.vm.network :private_network, ip: "192.168.60.6"
+    db.vm.network "private_network", ip: "192.168.60.6"
   end
 end


### PR DESCRIPTION
- OS:  macOS 10.15.6
- vagrant: 2.2.18
- virtualbox: 6.1

I could not log in via plain ssh before, as shown below

![image](https://user-images.githubusercontent.com/2959046/133054616-8360d8b5-fbcc-4637-8b17-6f71ee66047d.png)

After modifying the vagrantfile, I can log in with plain ssh

![image](https://user-images.githubusercontent.com/2959046/133054772-059d644f-d214-41a5-9520-979dcb8dcce4.png)
