### PR TITLE
composer executable isn't created until the next step (chapter 4 drupal, in: creates)

### DIFF
--- a/drupal/provisioning/playbook.yml
+++ b/drupal/provisioning/playbook.yml
@@ -123,7 +123,6 @@
       command: >
         php composer-installer.php
         chdir=/tmp
-        creates=/usr/local/bin/composer
 
     - name: Move Composer into globally-accessible location.
       command: >


### PR DESCRIPTION
Saw this while reading your (excellent) book: the file **/usr/local/bin/composer** isn't created until the next step which actually moves the executable to its destination.

I played up to this step on the vagrant server provided and verified that **/usr/local/bin/composer** indeed does not exist.