### PR TITLE
Issue #425: Fix Forever path and remove Remi repo.

### DIFF
--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -30,7 +30,7 @@ Note: *If there are any errors during the course of running `vagrant up`, and it
 
 ### 3 - Configure your host machine to access the VM.
 
-  1. [Edit your hosts file](http://docs.rackspace.com/support/how-to/modify-your-hosts-file/), adding the line `192.168.55.55  nodejs.test` so you can connect to the VM.
+  1. [Edit your hosts file](http://docs.rackspace.com/support/how-to/modify-your-hosts-file/), adding the line `192.168.56.55  nodejs.test` so you can connect to the VM.
   2. Open your browser and access [http://nodejs.test/](http://nodejs.test/).
 
 ## Notes

--- a/nodejs/Vagrantfile
+++ b/nodejs/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "geerlingguy/centos7"
   config.vm.hostname = "nodejs.test"
-  config.vm.network :private_network, ip: "192.168.55.55"
+  config.vm.network :private_network, ip: "192.168.56.55"
   config.ssh.insert_key = false
   config.vm.synced_folder ".", "/vagrant", disabled: true
 

--- a/nodejs/provisioning/playbook.yml
+++ b/nodejs/provisioning/playbook.yml
@@ -9,16 +9,6 @@
     - name: Install EPEL repo.
       yum: name=epel-release state=present
 
-    - name: Import Remi GPG key.
-      rpm_key:
-        key: "https://rpms.remirepo.net/RPM-GPG-KEY-remi"
-        state: present
-
-    - name: Install Remi repo.
-      yum:
-        name: "https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
-        state: present
-
     - name: Ensure firewalld is stopped (since this is a test server).
       service: name=firewalld state=stopped
 
@@ -38,10 +28,10 @@
       npm: "path={{ node_apps_location }}/app"
 
     - name: Check list of running Node.js apps.
-      command: forever list
+      command: /usr/local/bin/forever list
       register: forever_list
       changed_when: false
 
     - name: Start example Node.js app.
-      command: "forever start {{ node_apps_location }}/app/app.js"
+      command: "/usr/local/bin/forever start {{ node_apps_location }}/app/app.js"
       when: "forever_list.stdout.find(node_apps_location + '/app/app.js') == -1"


### PR DESCRIPTION
Fix the following problems about Ch4 nodejs server example:
1. After VirtualBox 6.1.26, there is a problem about original nodjs.test ip address. see [this](https://stackoverflow.com/questions/33953447/express-app-server-listen-all-interfaces-instead-of-localhost-only).
![image](https://user-images.githubusercontent.com/31841212/153342195-ed036711-3cab-45da-87b9-a525887b5925.png)
2. No need for Remi repo.
3. Can't run `forever xxx` command directly. 