### PR TITLE
name[play]: All plays should be named.

### DIFF
--- a/molecule/molecule/default/converge.yml
+++ b/molecule/molecule/default/converge.yml
@@ -9,4 +9,5 @@
         cache_valid_time: 3600
       when: ansible_os_family == 'Debian'
 
-- ansible.builtin.import_playbook: ../../main.yml
+- name: Import playbook
+  ansible.builtin.import_playbook: ../../main.yml


### PR DESCRIPTION
You get this linting warning:

```
name[play]: All plays should be named. (warning)
molecule/default/converge.yml:12
```