### PR TITLE
Add requirements and installation sections into README file

### DIFF
--- a/galaxy-role-servers/README.md
+++ b/galaxy-role-servers/README.md
@@ -2,6 +2,21 @@
 
 This folder contains two quick demo playbooks which build a LAMP and Apache Solr server, respectively, leaning entirely on Ansible Galaxy roles and their defaults for all functionality.
 
+## Requirements
+
+- Ansible 2.10 or higher
+
+## Installation
+
+To install the necessary dependencies, run:
+```shell
+pip install ansible==<version>
+```
+or to upgrade:
+```shell
+sudo pip install --upgrade ansible
+```
+
 ## Usage
 
 After running `vagrant up`, you can access the installed LAMP site or Solr Admin dashboard following these instructions:

--- a/galaxy-role-servers/README.md
+++ b/galaxy-role-servers/README.md
@@ -3,7 +3,7 @@
 This folder contains two quick demo playbooks which build a LAMP and Apache Solr server, respectively, leaning entirely on Ansible Galaxy roles and their defaults for all functionality.
 
 ## Requirements
-
+- Python 3.6 or higher
 - Ansible 2.10 or higher
 
 ## Installation


### PR DESCRIPTION
## Problem

Ansible versions up to and including 2.9.* fail to run the Galaxy roles. Old Ansible versions can't recognize `ansible.builtin` collection

[https://github.com/ansible/ansible/tags](https://github.com/ansible/ansible/tags) 
 
## Changes

- Added **Requirements** and **Installation** sections into README.md

## Screenshots

![](https://i.imgur.com/8nTBwGp.png)

## Testing

I tested the changes with:
- Vagrant 2.3.4
- Ansible 2.9.6 (fail) and 2.10.17 (success)

## Feedback

Please let me know if there's anything else you'd like me to address or if there are any changes you'd like me to make. I'm open to suggestions!
