### PR TITLE
fix drush installation task

### DIFF
--- a/drupal/provisioning/playbook.yml
+++ b/drupal/provisioning/playbook.yml
@@ -141,13 +141,18 @@
       become_user: www-data
       when: not drupal_composer_json.stat.exists
 
+    - name: Check if Drush already exists.
+      stat:
+        path: "{{ drupal_core_path }}/vendor/bin/drush"
+      register: drush_binary
+
     - name: Add drush to the Drupal site with Composer.
       composer:
         command: require
-        arguments: drush/drush:11.*
+        arguments: drush/drush:12.*
         working_dir: "{{ drupal_core_path }}"
       become_user: www-data
-      when: not drupal_composer_json.stat.exists
+      when: not drush_binary.stat.exists
 
     - name: Install Drupal.
       command: >


### PR DESCRIPTION
Update required drush version from 11 to 12 (see: https://www.drupal.org/node/3403057)

Add check for drush binary file existence and replace "when" conditional in drush installation task. This works better with progressive playbook runs (when you run playbook after each change) in which composer json file already exists. Offcourse its still not perfect as it checks only file's existence, without checking it's version. Yet for learning purposes i think its a sufficient compromise between reliability and simplicity.