### PR TITLE
escape dot in opcache.memory_consumption regex pattern for drupal

### DIFF
--- a/drupal/provisioning/playbook.yml
+++ b/drupal/provisioning/playbook.yml
@@ -87,7 +87,7 @@
     - name: Adjust OpCache memory setting.
       lineinfile:
         dest: "/etc/php/8.2/apache2/conf.d/10-opcache.ini"
-        regexp: "^opcache.memory_consumption"
+        regexp: "^opcache\\.memory_consumption"
         line: "opcache.memory_consumption = 96"
         state: present
       notify: restart apache


### PR DESCRIPTION
While both patterns would match the same string since . includes literal dot, escaping the dot with backslash is the clearer and more explicit approach  since . is a special regex metacharacter for matching any character.