### PR TITLE
Updated Droplet image_id for CentOS

### DIFF
--- a/dynamic-inventory/digitalocean/provision.yml
+++ b/dynamic-inventory/digitalocean/provision.yml
@@ -10,7 +10,7 @@
         name: ansible-test
         private_networking: yes
         size: 1gb
-        image_id: centos-7-x64
+        image_id: centos-stream-9-x64
         region: nyc3
         # Customize this for your account.
         ssh_keys:


### PR DESCRIPTION
Hi Jeff,

This PR changes the Droplet `image_id` value from the CentOS 7 id `centos-7-x64` to the CentOS stream 9 id `centos-stream-9-x64`. This is because the older id/slug for CentOS 7 doesn't work on DigitalOcean anymore, and gives me the error below.

```
PLAY [localhost] ***************************************************************

TASK [Create new Droplet.] *****************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to create Droplet [HTTP 422: You specified an invalid image for Droplet creation.]"}

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

I found a neat web tool that lists all of the valid DigitalOcean API slugs: [DigitalOcean API Slugs](https://slugs.do-api.dev/)

Thanks,
Seth